### PR TITLE
UppTerm: Code refactored.

### DIFF
--- a/app/UppTerm/main.cpp
+++ b/app/UppTerm/main.cpp
@@ -15,31 +15,21 @@ const char *tshell = "ComSpec"; // Alternatively you can use powershell...
 
 class UppTerm final : TopWindow {
 public:
-	UppTerm() {
+	UppTerm()
+	{
 		Title(m_title_prefix);
 		Icon(UppTermImg::Icon());
 		SetRect(m_terminal.GetStdSize());
 		Sizeable().Zoomable().CenterScreen().Add(m_terminal.SizePos());
 		
 		m_terminal.WindowReports();
-		m_terminal.WhenTitle = [=](String s) { Title(m_title_prefix + " :: " + s); };
+		m_terminal.WhenTitle  = [=](String s) { Title(m_title_prefix + " :: " + s); };
+		m_terminal.WhenOutput = [=](String s) { m_pty.Write(s); };
+		m_terminal.WhenResize = [=]()         {	m_pty.SetSize(m_terminal.GetPageSize()); };
 	}
-	
-	void Close() override {
-		if (m_pty.IsRunning()) {
-			m_pty.Kill();
-		}
-	}
-	
+
 	int Run(const String& cmd)
 	{
-		m_terminal.WhenOutput = [&](String s) {
-			m_pty.Write(s);
-		};
-		m_terminal.WhenResize = [&]() {
-			m_pty.SetSize(m_terminal.GetPageSize());
-		};
-		
 		m_pty.Start(cmd.IsEmpty() ? GetEnv(tshell) : cmd, Environment(), GetHomeDirectory());
 		
 		OpenMain();
@@ -53,9 +43,8 @@ public:
 				break;
 			Sleep(l >= 1024 ? 1024 * 10 / l : 10);
 		}
-		const auto exit_code = m_pty.GetExitCode();
-		m_pty.Kill();
-		return exit_code;
+		
+		return m_pty.GetExitCode();
 	}
 
 private:
@@ -78,3 +67,4 @@ GUI_APP_MAIN
 	
 	SetExitCode(UppTerm().Run(cmd));
 }
+

--- a/app/UppTerm/main.cpp
+++ b/app/UppTerm/main.cpp
@@ -39,7 +39,7 @@ public:
 			String s = m_pty.Get();
 			int l = s.GetLength();
 			m_terminal.WriteUtf8(s);
-			if(!m_pty.IsRunning())
+			if(!m_pty.IsRunning() || !IsOpen())
 				break;
 			Sleep(l >= 1024 ? 1024 * 10 / l : 10);
 		}


### PR DESCRIPTION
This is a suggestion, feel free to discard it.

I refactored the code so that the new-comers can understand it easily.  

1) We don't need to call `PtyProcess::Kill()` method explicitly as it is already called in the destructor. Hence no need to override the `TopWindow::Close()` method either.
2) TerminalCtrl-PtyProcess connectors are "all over the place". Since this code is meant to be a basic setup, I'd say let's not make things more complicated than needed. Connectors can (and IMO should) be defined in the constructor. 