### PR TITLE
Update to UppTerm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,9 @@ build:
 	
 download:
 	mkdir -p 3p/download
-	wget https://github.com/ultimatepp/ultimatepp/releases/download/2024.1/uppsrc-17458.tar.gz -P 3p/download
-	wget https://github.com/ultimatepp/ultimatepp/releases/download/2024.1/umk-17458-linux-x86-64.tar.gz -P 3p/download
-	tar -xf 3p/download/uppsrc-17458.tar.gz -C 3p
+	wget https://github.com/ultimatepp/ultimatepp/releases/download/v2025.1/uppsrc-17799.tar.gz  -P 3p/download
+	wget https://github.com/ultimatepp/ultimatepp/releases/download/v2024.1/umk-17458-linux-x86-64.tar.gz -P 3p/download
+	tar -xf 3p/download/uppsrc-17799.tar.gz -C 3p
 	tar -xf 3p/download/umk-17458-linux-x86-64.tar.gz -C 3p
 
 run:


### PR DESCRIPTION
This PR updates the UppTerm

- Adds proper event waiting using the new `PtyWaitEvent` (Included in TerminalCtrl 2025.2)
- Makefile is updated to use Upp 2025.1 (Fixes path error too)

Overall, the new version of TerminalCtrl is much more robust, fast and efficient.
Now, so is UppTerm.