### PR TITLE
PtyProcess/PtyWaitEvent wait workaround.

### DIFF
--- a/app/UppTerm/main.cpp
+++ b/app/UppTerm/main.cpp
@@ -39,8 +39,8 @@ public:
 		PtyWaitEvent we;
 		we.Add(m_pty, WAIT_READ | WAIT_IS_EXCEPTION);
 		while(IsOpen() && m_pty.IsRunning()) {
-			if(we.Wait(10))
-				m_terminal.WriteUtf8(m_pty.Get());
+			we.Wait(10);
+			m_terminal.WriteUtf8(m_pty.Get());
 			ProcessEvents();
 		}
 
@@ -67,3 +67,4 @@ GUI_APP_MAIN
 
 	SetExitCode(UppTerm().Run(cmd));
 }
+


### PR DESCRIPTION
There seems to be a bug in PtyWaitEvent that makes Wait always return false (on Windows). So this is a workaround.
 
This patch makes `Wait` effectively the same as `Sleep`. (It will always wait 10 ms on Windows). Harmless, but definitely needs fixing in the following days.